### PR TITLE
Bumping juice version + update describe

### DIFF
--- a/package.js
+++ b/package.js
@@ -1,11 +1,12 @@
 Package.describe({
   summary: "Juice wrapper package",
-  version: '0.1.0',
-  name: "juice"
+  version: '0.1.1',
+  name: "sacha:juice",
+  git: "https://github.com/SachaG/meteor-juice"
 });
 
 Npm.depends({
-  juice: "0.4.0", 
+  juice: "0.5.0", 
 });
 
 Package.onUse(function (api) {


### PR DESCRIPTION
I updated the describe info based on https://meteor.hackpad.com/Unipackage-tvas8pXYMOW so that the github link and README show up on atmospherejs. I'm also hoping the name update makes https://github.com/TelescopeJS/Telescope/issues/388 better, but it seemed like it couldn't hurt.

If this is merged then it will need to be published (meteor publish). I figure you know that, but it seemed safer to mention it :)
